### PR TITLE
Add new HomeSeer Z-Wave device types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Z-Wave devices of the following types should create entities in Home Assistant:
 - Z-Wave Switch Binary (as Home Assistant switch)
 - Z-Wave Switch Multilevel (as Home Assistant light)
 - Z-Wave Central Scene (as Home Assistant event - see below)
+- Z-Wave Temperature (as Home Assistant sensor)
+- Z-Wave Relative Humidity (as Home Assistant sensor)
+- Z-Wave Luminance (as Home Assistant sensor)
+- Z-Wave Fan State for HVAC (as Home Assistant sensor)
+- Z-Wave Operating State for HVAC (as Home Assistant sensor)
+
 
 HomeSeer Events will be created as Home Assistant scenes (triggering the scene in Home Assistant will run the HomeSeer event).
 
@@ -47,21 +53,23 @@ homeseer:
   username: default
   password: default
   location_names: False
+  location2_names: False
   allow_events: True
 ```
 |Parameter|Description|Required/Optional|
 |---------|-----------|-----------------|
 |host|IP address of the HomeSeer HS3 HomeTroller|Required|
-|port|HTTP port of the HomeTroller|Optional, default 80|
+|http_port|HTTP port of the HomeTroller|Optional, default 80|
 |ascii_port|ASCII port of the HomeTroller|Optional, default 11000|
 |username|Username of the user to connect to the HomeTroller|Optional, default "default"|
 |password|Password of the user to connect to the HomeTroller|Optional, default "default"|
-|location_names|Append location2 + location to device name (see below)|Optional, default False|
+|location_names|Prepend location to device name (see below)|Optional, default False|
+|location2_names|Prepend location2 to device name (see below)|Optional, default False|
 |allow_events|Create Home Assistant scenes for HomeSeer events|Optional, default True|
 
-### location_names
+### location_names and location2_names
 
-By default entities will be named only the name of the device in HomeSeer. If you want the location2 + location fields to be appended to the name, set location_names to True.
+By default entities will be named only the name of the device in HomeSeer. If you want the location2 and/or location fields to be prepended to the name, set location2_names and/or location_names to True.
 
 Example:
 - HomeSeer location2 "Main Floor"
@@ -69,6 +77,7 @@ Example:
 - HomeSeer device name "Lamp"
 
 Result:
-- location_names = False: Home Assistant entity will be called "Lamp"
-- location_names = True: Home Assistant entity will be called "Main Floor Living Room Lamp"
-
+- Both = False: Home Assistant entity will be called "Lamp"
+- location_names = True: Home Assistant entity will be called "Living Room Lamp"
+- location2_names = True: Home Assistant entity will be called "Main Floor Lamp"
+- Both = True: Home Assistant entity will be called "Main Floor Living Room Lamp"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ homeseer:
   username: default
   password: default
   location_names: False
-  location2_names: False
   allow_events: True
 ```
 |Parameter|Description|Required/Optional|
@@ -63,13 +62,12 @@ homeseer:
 |ascii_port|ASCII port of the HomeTroller|Optional, default 11000|
 |username|Username of the user to connect to the HomeTroller|Optional, default "default"|
 |password|Password of the user to connect to the HomeTroller|Optional, default "default"|
-|location_names|Prepend location to device name (see below)|Optional, default False|
-|location2_names|Prepend location2 to device name (see below)|Optional, default False|
+|location_names|Prepend location2 + location to device name (see below)|Optional, default False|
 |allow_events|Create Home Assistant scenes for HomeSeer events|Optional, default True|
 
-### location_names and location2_names
+### location_names
 
-By default entities will be named only the name of the device in HomeSeer. If you want the location2 and/or location fields to be prepended to the name, set location2_names and/or location_names to True.
+By default entities will be named only the name of the device in HomeSeer. If you want the location2 + location fields to be prepended to the name, set location_names to True.
 
 Example:
 - HomeSeer location2 "Main Floor"
@@ -77,7 +75,5 @@ Example:
 - HomeSeer device name "Lamp"
 
 Result:
-- Both = False: Home Assistant entity will be called "Lamp"
-- location_names = True: Home Assistant entity will be called "Living Room Lamp"
-- location2_names = True: Home Assistant entity will be called "Main Floor Lamp"
-- Both = True: Home Assistant entity will be called "Main Floor Living Room Lamp"
+- location_names = False: Home Assistant entity will be called "Lamp"
+- location_names = True: Home Assistant entity will be called "Main Floor Living Room Lamp"

--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,6 @@ DOMAIN = 'homeseer'
 CONF_HTTP_PORT = 'http_port'
 CONF_ASCII_PORT = 'ascii_port'
 CONF_LOCATION_NAMES = 'location_names'
-CONF_LOCATION2_NAMES = 'location2_names'
 CONF_ALLOW_EVENTS = 'allow_events'
 
 DEFAULT_HTTP_PORT = 80
@@ -29,7 +28,6 @@ DEFAULT_PASSWORD = 'default'
 DEFAULT_USERNAME = 'default'
 DEFAULT_ASCII_PORT = 11000
 DEFAULT_LOCATION_NAMES = False
-DEFAULT_LOCATION2_NAMES = False
 DEFAULT_ALLOW_EVENTS = True
 
 CONFIG_SCHEMA = vol.Schema({
@@ -40,7 +38,6 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_HTTP_PORT, default=DEFAULT_HTTP_PORT): cv.port,
         vol.Optional(CONF_ASCII_PORT, default=DEFAULT_ASCII_PORT): cv.port,
         vol.Optional(CONF_LOCATION_NAMES, default=DEFAULT_LOCATION_NAMES): cv.boolean,
-        vol.Optional(CONF_LOCATION2_NAMES, default=DEFAULT_LOCATION2_NAMES): cv.boolean,
         vol.Optional(CONF_ALLOW_EVENTS, default=DEFAULT_ALLOW_EVENTS): cv.boolean
     })
 }, extra=vol.ALLOW_EXTRA)
@@ -59,11 +56,9 @@ async def async_setup(hass, config):
     http_port = config[CONF_HTTP_PORT]
     ascii_port = config[CONF_ASCII_PORT]
     location_names = config[CONF_LOCATION_NAMES]
-    location2_names = config[CONF_LOCATION2_NAMES]
     allow_events = config[CONF_ALLOW_EVENTS]
 
-    homeseer = HSConnection(hass, host, username, password, http_port, ascii_port,
-                            location_names, location2_names)
+    homeseer = HSConnection(hass, host, username, password, http_port, ascii_port, location_names)
 
     await homeseer.api.initialize()
     if len(homeseer.devices) == 0 and len(homeseer.events) == 0:
@@ -100,14 +95,13 @@ async def async_setup(hass, config):
 
 class HSConnection:
     """Manages a connection between HomeSeer and Home Assistant."""
-    def __init__(self, hass, host, username, password, http_port, ascii_port, location_names, location2_names):
+    def __init__(self, hass, host, username, password, http_port, ascii_port, location_names):
         from pyhs3 import HomeTroller
         self._hass = hass
         self._session = aiohttp_client.async_get_clientsession(self._hass)
         self.api = HomeTroller(host, self._session, username=username, password=password,
                                http_port=http_port, ascii_port=ascii_port)
         self._location_names = location_names
-        self._location2_names = location2_names
         self.remotes = []
 
     @property
@@ -121,10 +115,6 @@ class HSConnection:
     @property
     def location_names(self):
         return self._location_names
-
-    @property
-    def location2_names(self):
-        return self._location2_names
 
     async def start(self):
         await self.api.start_listener()

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -45,15 +45,19 @@ class HSBinarySensor(BinarySensorDevice):
         attr = {
             'Device Ref': self._device.ref,
             'Location': self._device.location,
-            'Location 2': self._device.location2
+            'Location2': self._device.location2
         }
         return attr
 
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
+        if self._connection.location2_names and self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
+        elif self._connection.location2_names:
+            return '{} {}'.format(self._device.location2, self._device.name)
+        elif self._connection.location_names:
+            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -52,12 +52,8 @@ class HSBinarySensor(BinarySensorDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location2_names and self._connection.location_names:
+        if self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        elif self._connection.location2_names:
-            return '{} {}'.format(self._device.location2, self._device.name)
-        elif self._connection.location_names:
-            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/cover.py
+++ b/cover.py
@@ -44,15 +44,21 @@ class HSCover(CoverDevice):
     @property
     def device_state_attributes(self):
         attr = {
-            'Device Ref': self._device.ref
+            'Device Ref': self._device.ref,
+            'Location': self._device.location,
+            'Location2': self._device.location2
         }
         return attr
 
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
+        if self._connection.location2_names and self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
+        elif self._connection.location2_names:
+            return '{} {}'.format(self._device.location2, self._device.name)
+        elif self._connection.location_names:
+            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/cover.py
+++ b/cover.py
@@ -53,12 +53,8 @@ class HSCover(CoverDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location2_names and self._connection.location_names:
+        if self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        elif self._connection.location2_names:
-            return '{} {}'.format(self._device.location2, self._device.name)
-        elif self._connection.location_names:
-            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/light.py
+++ b/light.py
@@ -53,12 +53,8 @@ class HSLight(Light):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location2_names and self._connection.location_names:
+        if self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        elif self._connection.location2_names:
-            return '{} {}'.format(self._device.location2, self._device.name)
-        elif self._connection.location_names:
-            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/light.py
+++ b/light.py
@@ -43,15 +43,22 @@ class HSLight(Light):
     @property
     def device_state_attributes(self):
         attr = {
-            'Device Ref': self._device.ref
+            'Device Ref': self._device.ref,
+            'Location': self._device.location,
+            'Location2': self._device.location2
+
         }
         return attr
 
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
+        if self._connection.location2_names and self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
+        elif self._connection.location2_names:
+            return '{} {}'.format(self._device.location2, self._device.name)
+        elif self._connection.location_names:
+            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/lock.py
+++ b/lock.py
@@ -43,15 +43,21 @@ class HSLock(LockDevice):
     @property
     def device_state_attributes(self):
         attr = {
-            'Device Ref': self._device.ref
+            'Device Ref': self._device.ref,
+            'Location': self._device.location,
+            'Location2': self._device.location2
         }
         return attr
 
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
+        if self._connection.location2_names and self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
+        elif self._connection.location2_names:
+            return '{} {}'.format(self._device.location2, self._device.name)
+        elif self._connection.location_names:
+            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/lock.py
+++ b/lock.py
@@ -52,12 +52,8 @@ class HSLock(LockDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location2_names and self._connection.location_names:
+        if self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        elif self._connection.location2_names:
-            return '{} {}'.format(self._device.location2, self._device.name)
-        elif self._connection.location_names:
-            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "homeseer",
+  "name": "HomeSeer",
+  "documentation": "https://github.com/marthoc/homeseer",
+  "dependencies": [],
+  "codeowners": ["@marthoc"],
+  "requirements": ["pyhs3==0.10"]
+}

--- a/sensor.py
+++ b/sensor.py
@@ -47,15 +47,21 @@ class HSSensor(Entity):
     @property
     def device_state_attributes(self):
         attr = {
-            'Device Ref': self._device.ref
+            'Device Ref': self._device.ref,
+            'Location': self._device.location,
+            'Location2': self._device.location2
         }
         return attr
 
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
+        if self._connection.location2_names and self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
+        elif self._connection.location2_names:
+            return '{} {}'.format(self._device.location2, self._device.name)
+        elif self._connection.location_names:
+            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/sensor.py
+++ b/sensor.py
@@ -71,12 +71,8 @@ class HSSensor(Entity):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location2_names and self._connection.location_names:
+        if self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        elif self._connection.location2_names:
-            return '{} {}'.format(self._device.location2, self._device.name)
-        elif self._connection.location_names:
-            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/switch.py
+++ b/switch.py
@@ -52,12 +52,8 @@ class HSSwitch(SwitchDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location2_names and self._connection.location_names:
+        if self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        elif self._connection.location2_names:
-            return '{} {}'.format(self._device.location2, self._device.name)
-        elif self._connection.location_names:
-            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 

--- a/switch.py
+++ b/switch.py
@@ -43,15 +43,21 @@ class HSSwitch(SwitchDevice):
     @property
     def device_state_attributes(self):
         attr = {
-            'Device Ref': self._device.ref
+            'Device Ref': self._device.ref,
+            'Location': self._device.location,
+            'Location2': self._device.location2
         }
         return attr
 
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
+        if self._connection.location2_names and self._connection.location_names:
             return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
+        elif self._connection.location2_names:
+            return '{} {}'.format(self._device.location2, self._device.name)
+        elif self._connection.location_names:
+            return '{} {}'.format(self._device.location, self._device.name)
         else:
             return self._device.name
 


### PR DESCRIPTION
* Added support for the following HS devices as a subclass of HSSensor:

  - HSTemperature
  - HSHumidity
  - HSLuminance
  - HSFanState
  - HSOperatingState


* Created manifest.json file to by HA 0.92+ compliant.

* Added config option 'location2_names' and changed the functionality of 'location_names'.

* Changed entity attribute 'Location 2' to 'Location2' to align with config option.

* Added entity attributes "Location" and "Location2" to all platforms.
