### PR TITLE
Added ability to provide template for device names

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ homeseer:
   ascii_port: 11000
   username: default
   password: default
+  name_template: '{{ device.name }}'
   location_names: False
   allow_events: True
 ```
@@ -56,12 +57,14 @@ homeseer:
 |ascii_port|ASCII port of the HomeTroller|Optional, default 11000|
 |username|Username of the user to connect to the HomeTroller|Optional, default "default"|
 |password|Password of the user to connect to the HomeTroller|Optional, default "default"|
-|location_names|Append location2 + location to device name (see below)|Optional, default False|
+|name_template|Jinja2 template for naming devices|Optional, default "{{ device.name }}"|
+|location_names|Deprecated. Overrides default name_template to include locations| Optional, default False|
 |allow_events|Create Home Assistant scenes for HomeSeer events|Optional, default True|
 
-### location_names
+### name_template
 
-By default entities will be named only the name of the device in HomeSeer. If you want the location2 + location fields to be appended to the name, set location_names to True.
+By default entities will only include the name of the device in HomeSeer. If you want the location fields 
+to be included, you can add these fields to the "name_template" string.
 
 Example:
 - HomeSeer location2 "Main Floor"
@@ -69,6 +72,7 @@ Example:
 - HomeSeer device name "Lamp"
 
 Result:
-- location_names = False: Home Assistant entity will be called "Lamp"
-- location_names = True: Home Assistant entity will be called "Main Floor Living Room Lamp"
+- name_template = "{{ device.name }}": Home Assistant entity will be called "Lamp"
+- name_template = "{{ device.location }} - {{ device.name }}": Home Assistant entity will be called "Living Room - Lamp"
+- name_template = "{{ device.location2 }} {{ device.location }} {{ device.name }}": Home Assistant entity will be called "Main Floor Living Room Lamp"
 

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import EventOrigin
 from homeassistant.helpers import aiohttp_client, discovery
-from jinja2 import Template
 
 from .const import (
     _LOGGER,
@@ -73,6 +72,8 @@ async def async_setup(hass, config):
     ascii_port = config[CONF_ASCII_PORT]
     name_template = config[CONF_NAME_TEMPLATE]
     allow_events = config[CONF_ALLOW_EVENTS]
+
+    name_template.hass = hass
 
     homeseer = HSConnection(
         hass, host, username, password, http_port, ascii_port, namespace, name_template

--- a/__init__.py
+++ b/__init__.py
@@ -51,7 +51,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
                 vol.Optional(CONF_HTTP_PORT, default=DEFAULT_HTTP_PORT): cv.port,
                 vol.Optional(CONF_ASCII_PORT, default=DEFAULT_ASCII_PORT): cv.port,
-                vol.Optional(CONF_NAME_TEMPLATE, default=DEFAULT_NAME_TEMPLATE) : cv.string,
+                vol.Optional(CONF_NAME_TEMPLATE, default=DEFAULT_NAME_TEMPLATE) : cv.template,
                 vol.Optional(
                     CONF_ALLOW_EVENTS, default=DEFAULT_ALLOW_EVENTS
                 ): cv.boolean,
@@ -131,7 +131,7 @@ class HSConnection:
             ascii_port=ascii_port,
         )
         self._namespace = namespace
-        self._name_template = Template(name_template)
+        self._name_template = name_template
         self.remotes = []
 
     @property

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -52,10 +52,7 @@ class HSBinarySensor(BinarySensorDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
-            return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        else:
-            return self._device.name
+        return self._connection.name_template.render(device = self._device)
 
     @property
     def should_poll(self):

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -54,7 +54,7 @@ class HSBinarySensor(BinarySensorDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        return self._connection.name_template.render(device=self._device).strip()
+        return self._connection.name_template.async_render(device=self._device).strip()
 
     @property
     def should_poll(self):

--- a/cover.py
+++ b/cover.py
@@ -55,7 +55,7 @@ class HSCover(CoverDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        return self._connection.name_template.render(device=self._device).strip()
+        return self._connection.name_template.async_render(device=self._device).strip()
 
     @property
     def should_poll(self):

--- a/cover.py
+++ b/cover.py
@@ -51,10 +51,7 @@ class HSCover(CoverDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
-            return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        else:
-            return self._device.name
+        return self._connection.name_template.render(device = self._device)
 
     @property
     def should_poll(self):

--- a/light.py
+++ b/light.py
@@ -50,10 +50,7 @@ class HSLight(Light):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
-            return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        else:
-            return self._device.name
+        return self._connection.name_template.render(device = self._device)
 
     @property
     def should_poll(self):

--- a/light.py
+++ b/light.py
@@ -54,7 +54,7 @@ class HSLight(Light):
     @property
     def name(self):
         """Return the name of the device."""
-        return self._connection.name_template.render(device=self._device).strip()
+        return self._connection.name_template.async_render(device=self._device).strip()
 
     @property
     def should_poll(self):

--- a/lock.py
+++ b/lock.py
@@ -50,10 +50,7 @@ class HSLock(LockDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
-            return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        else:
-            return self._device.name
+        return self._connection.name_template.render(device = self._device)
 
     @property
     def should_poll(self):

--- a/lock.py
+++ b/lock.py
@@ -54,7 +54,7 @@ class HSLock(LockDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        return self._connection.name_template.render(device=self._device).strip()
+        return self._connection.name_template.async_render(device=self._device).strip()
 
     @property
     def should_poll(self):

--- a/sensor.py
+++ b/sensor.py
@@ -54,10 +54,7 @@ class HSSensor(Entity):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
-            return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        else:
-            return self._device.name
+        return self._connection.name_template.render(device = self._device)
 
     @property
     def state(self):

--- a/sensor.py
+++ b/sensor.py
@@ -58,7 +58,7 @@ class HSSensor(Entity):
     @property
     def name(self):
         """Return the name of the device."""
-        return self._connection.name_template.render(device=self._device).strip()
+        return self._connection.name_template.async_render(device=self._device).strip()
 
     @property
     def state(self):

--- a/switch.py
+++ b/switch.py
@@ -50,10 +50,7 @@ class HSSwitch(SwitchDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._connection.location_names:
-            return '{} {} {}'.format(self._device.location2, self._device.location, self._device.name)
-        else:
-            return self._device.name
+        return self._connection.name_template.render(device = self._device)
 
     @property
     def should_poll(self):

--- a/switch.py
+++ b/switch.py
@@ -54,7 +54,7 @@ class HSSwitch(SwitchDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        return self._connection.name_template.render(device=self._device).strip()
+        return self._connection.name_template.async_render(device=self._device).strip()
 
     @property
     def should_poll(self):


### PR DESCRIPTION
Added a new configuration option `name_template`. 

The Jinja2 template can be used to evaluate device properties when constructing device names for HomeAssistant. This gives users more flexibility in ensuring that HomeSeer device names match their existing HomeAssistant naming scheme (for example, I don't need location2, but I separate room and device name with a hyphen). The behavior of this new option is consistent with existing functionality, including `location_names`.

The default template is `{{ device.name }}` which matches existing default names. The most obvious choice for users is to use locations (for example `{{ device.location }} - {{ device.name }}`). 

When `location_names` is set to `True` it will take precedence over any user `name_template` and override the template effectively to `{{ device.location2 }} {{ device.location }} {{ device.name }}`. This ensures backwards compatibility. 

If backwards compatibility is not a concern, I would suggest removing `location_names` completely, as its behavior can be replicated with `name_template`.