### PR TITLE
Add support for Z-Wave Switch Multilevel blinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Z-Wave devices of the following types should create entities in Home Assistant:
 - Z-Wave Sensor Binary (as Home Assistant binary sensor)
 - Z-Wave Switch (as Home Assistant switch)
 - Z-Wave Switch Binary (as Home Assistant switch)
-- Z-Wave Switch Multilevel (as Home Assistant light)
+- Z-Wave Switch Multilevel (as Home Assistant light or cover)
 - Z-Wave Central Scene (as Home Assistant event - see below)
 - Z-Wave Temperature (as Home Assistant sensor)
 - Z-Wave Relative Humidity (as Home Assistant sensor)
@@ -54,6 +54,7 @@ homeseer:
   password: default
   name_template: '{{ device.name }}'
   allow_events: True
+  forced_covers: [ 10, 20, 30 ]
 ```
 |Parameter|Description|Required/Optional|
 |---------|-----------|-----------------|
@@ -65,6 +66,7 @@ homeseer:
 |password|Password of the user to connect to the HomeTroller|Optional, default "default"|
 |name_template|Jinja2 template for naming devices|Optional, default "{{ device.location2 }} {{ device.location }} {{ device.name }}"|
 |allow_events|Create Home Assistant scenes for HomeSeer events|Optional, default True|
+|forced_covers|List of refs of Z-Wave Switch Multilevels that should be represented in HA as covers|Optional, default all ZWSM to lights|
 
 ### Namespace
 

--- a/__init__.py
+++ b/__init__.py
@@ -24,11 +24,13 @@ from .const import (
     _LOGGER,
     CONF_ALLOW_EVENTS,
     CONF_ASCII_PORT,
+    CONF_FORCED_COVERS,
     CONF_HTTP_PORT,
     CONF_NAME_TEMPLATE,
     CONF_NAMESPACE,
     DEFAULT_ALLOW_EVENTS,
     DEFAULT_ASCII_PORT,
+    DEFAULT_FORCED_COVERS,
     DEFAULT_HTTP_PORT,
     DEFAULT_PASSWORD,
     DEFAULT_USERNAME,
@@ -50,10 +52,15 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
                 vol.Optional(CONF_HTTP_PORT, default=DEFAULT_HTTP_PORT): cv.port,
                 vol.Optional(CONF_ASCII_PORT, default=DEFAULT_ASCII_PORT): cv.port,
-                vol.Optional(CONF_NAME_TEMPLATE, default=DEFAULT_NAME_TEMPLATE) : cv.template,
+                vol.Optional(
+                    CONF_NAME_TEMPLATE, default=DEFAULT_NAME_TEMPLATE
+                ): cv.template,
                 vol.Optional(
                     CONF_ALLOW_EVENTS, default=DEFAULT_ALLOW_EVENTS
                 ): cv.boolean,
+                vol.Optional(
+                    CONF_FORCED_COVERS, default=DEFAULT_FORCED_COVERS
+                ): cv.ensure_list,
             }
         )
     },
@@ -72,6 +79,7 @@ async def async_setup(hass, config):
     ascii_port = config[CONF_ASCII_PORT]
     name_template = config[CONF_NAME_TEMPLATE]
     allow_events = config[CONF_ALLOW_EVENTS]
+    forced_covers = config[CONF_FORCED_COVERS]
 
     name_template.hass = hass
 
@@ -105,7 +113,9 @@ async def async_setup(hass, config):
 
     for platform in HOMESEER_PLATFORMS:
         hass.async_create_task(
-            discovery.async_load_platform(hass, platform, DOMAIN, {}, config)
+            discovery.async_load_platform(
+                hass, platform, DOMAIN, {CONF_FORCED_COVERS: forced_covers}, config
+            )
         )
 
     hass.data[DOMAIN] = homeseer
@@ -119,7 +129,15 @@ class HSConnection:
     """Manages a connection between HomeSeer and Home Assistant."""
 
     def __init__(
-        self, hass, host, username, password, http_port, ascii_port, namespace, name_template
+        self,
+        hass,
+        host,
+        username,
+        password,
+        http_port,
+        ascii_port,
+        namespace,
+        name_template,
     ):
         self._hass = hass
         self._session = aiohttp_client.async_get_clientsession(self._hass)

--- a/const.py
+++ b/const.py
@@ -15,6 +15,7 @@ CONF_ASCII_PORT = "ascii_port"
 CONF_ALLOW_EVENTS = "allow_events"
 CONF_NAMESPACE = "namespace"
 CONF_NAME_TEMPLATE = "name_template"
+CONF_FORCED_COVERS = "forced_covers"
 
 DEFAULT_HTTP_PORT = 80
 DEFAULT_PASSWORD = "default"
@@ -22,6 +23,7 @@ DEFAULT_USERNAME = "default"
 DEFAULT_ASCII_PORT = 11000
 DEFAULT_NAME_TEMPLATE = "{{ device.location2 }} {{ device.location }} {{ device.name }}"
 DEFAULT_ALLOW_EVENTS = True
+DEFAULT_FORCED_COVERS = []
 
 HOMESEER_PLATFORMS = [
     "binary_sensor",

--- a/cover.py
+++ b/cover.py
@@ -128,8 +128,7 @@ class HSBlind(HSCover):
     @property
     def supported_features(self):
         """Return the features supported by the device."""
-        features = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
-        return features
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
 
     @property
     def device_class(self):
@@ -139,12 +138,12 @@ class HSBlind(HSCover):
     @property
     def current_cover_position(self):
         """Return the current position of the cover."""
-        return self._device.dim_percent
+        return int(self._device.dim_percent * 100)
 
     @property
     def is_closed(self):
         """Return if the cover is closed or not."""
-        return self._device.dim_percent == 0
+        return not self._device.is_on
 
     async def async_open_cover(self, **kwargs):
         await self._device.on()

--- a/cover.py
+++ b/cover.py
@@ -2,12 +2,24 @@
 Support for HomeSeer cover-type devices.
 """
 
-from pyhs3 import HASS_COVERS, STATE_LISTENING
+from pyhs3 import (
+    STATE_LISTENING,
+    DEVICE_ZWAVE_BARRIER_OPERATOR,
+    DEVICE_ZWAVE_SWITCH_MULTILEVEL,
+)
 
-from homeassistant.components.cover import CoverEntity
+from homeassistant.components.cover import (
+    CoverEntity,
+    ATTR_POSITION,
+    DEVICE_CLASS_BLIND,
+    DEVICE_CLASS_GARAGE,
+    SUPPORT_CLOSE,
+    SUPPORT_OPEN,
+    SUPPORT_SET_POSITION,
+)
 from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPENING
 
-from .const import _LOGGER, DOMAIN
+from .const import _LOGGER, DOMAIN, CONF_FORCED_COVERS
 
 DEPENDENCIES = ["homeseer"]
 
@@ -15,19 +27,26 @@ DEPENDENCIES = ["homeseer"]
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up HomeSeer cover-type devices."""
     cover_devices = []
+    forced_covers = discovery_info[CONF_FORCED_COVERS]
     homeseer = hass.data[DOMAIN]
 
     for device in homeseer.devices:
-        if device.device_type_string in HASS_COVERS:
-            dev = HSCover(device, homeseer)
+        if device.device_type_string == DEVICE_ZWAVE_BARRIER_OPERATOR:
+            """Device is a garage-door opener."""
+            dev = HSGarage(device, homeseer)
             cover_devices.append(dev)
-            _LOGGER.info(f"Added HomeSeer cover-type device: {dev.name}")
+            _LOGGER.info(f"Added HomeSeer garage-type device: {dev.name}")
+        elif device.device_type_string == DEVICE_ZWAVE_SWITCH_MULTILEVEL and int(device.ref) in forced_covers:
+            """Device is a blind."""
+            dev = HSBlind(device, homeseer)
+            cover_devices.append(dev)
+            _LOGGER.info(f"Added HomeSeer blind-type device: {dev.name}")
 
     async_add_entities(cover_devices)
 
 
 class HSCover(CoverEntity):
-    """Representation of a HomeSeer cover-type device."""
+    """Base representation of a HomeSeer cover-type device."""
 
     def __init__(self, device, connection):
         self._device = device
@@ -62,6 +81,25 @@ class HSCover(CoverEntity):
         """No polling needed."""
         return False
 
+    async def async_added_to_hass(self):
+        """Register value update callback."""
+        self._device.register_update_callback(self.async_schedule_update_ha_state)
+
+
+class HSGarage(HSCover):
+    """Representation of a garage door opener device."""
+
+    @property
+    def supported_features(self):
+        """Return the features supported by the device."""
+        features = SUPPORT_OPEN | SUPPORT_CLOSE
+        return features
+
+    @property
+    def device_class(self):
+        """Return the device class for the device."""
+        return DEVICE_CLASS_GARAGE
+
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
@@ -83,6 +121,36 @@ class HSCover(CoverEntity):
     async def async_close_cover(self, **kwargs):
         await self._device.close()
 
-    async def async_added_to_hass(self):
-        """Register value update callback."""
-        self._device.register_update_callback(self.async_schedule_update_ha_state)
+
+class HSBlind(HSCover):
+    """Representation of a window-covering device."""
+
+    @property
+    def supported_features(self):
+        """Return the features supported by the device."""
+        features = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
+        return features
+
+    @property
+    def device_class(self):
+        """Return the device class for the device."""
+        return DEVICE_CLASS_BLIND
+
+    @property
+    def current_cover_position(self):
+        """Return the current position of the cover."""
+        return self._device.dim_percent
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed or not."""
+        return self._device.dim_percent == 0
+
+    async def async_open_cover(self, **kwargs):
+        await self._device.on()
+
+    async def async_close_cover(self, **kwargs):
+        await self._device.off()
+
+    async def async_set_cover_position(self, **kwargs):
+        await self._device.dim(kwargs.get(ATTR_POSITION, 0))

--- a/light.py
+++ b/light.py
@@ -6,7 +6,7 @@ from pyhs3 import HASS_LIGHTS, STATE_LISTENING
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, LightEntity
 
-from .const import _LOGGER, DOMAIN
+from .const import _LOGGER, DOMAIN, CONF_FORCED_COVERS
 
 DEPENDENCIES = ["homeseer"]
 
@@ -14,10 +14,11 @@ DEPENDENCIES = ["homeseer"]
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up HomeSeer light-type devices."""
     light_devices = []
+    forced_covers = discovery_info[CONF_FORCED_COVERS]
     homeseer = hass.data[DOMAIN]
 
     for device in homeseer.devices:
-        if device.device_type_string in HASS_LIGHTS:
+        if device.device_type_string in HASS_LIGHTS and int(device.ref) not in forced_covers:
             dev = HSLight(device, homeseer)
             light_devices.append(dev)
             _LOGGER.info(f"Added HomeSeer light-type device: {dev.name}")


### PR DESCRIPTION
Some Z-Wave blinds are represented in HomeSeer as Z-Wave Switch Multilevels - this PR introduces a new configuration option that allows the user to force certain ZWSMs to be represented correctly in HA as covers.