### PR TITLE
1.1.0

### DIFF
--- a/custom_components/homeseer/homeseer.py
+++ b/custom_components/homeseer/homeseer.py
@@ -155,14 +155,6 @@ class HomeSeerBridge:
         This method ensures that a HomeSeer device will only ever be represented in one platform,
         and filters out devices as required.
         """
-        # Filter out HomeSeer "Root" devices; they will be used for device info at the entity level only.
-        if device.relationship == RELATIONSHIP_ROOT:
-            _LOGGER.debug(
-                f"Device ref {device.ref} is a root device, "
-                f"not creating an entity for this device"
-            )
-            return None
-
         # Filter out devices from interfaces not selected during the Config Flow.
         iname = (
             device.interface_name


### PR DESCRIPTION
Enable root devices as entities (#58)

Removed code which filtered out HomeSeer root devices; while these devices are not used by the Z-Wave PI for any control or status purpose, they appear to be used by other PIs (e.g. Insteon) for control/status. Enabling them will have no drawback for Z-Wave (an additional useless entity will be created).